### PR TITLE
Pubsub 1723

### DIFF
--- a/pubsub/integration_test.go
+++ b/pubsub/integration_test.go
@@ -1133,8 +1133,8 @@ func TestIntegration_OrderedKeys_Basic(t *testing.T) {
 		})
 		go func() {
 			<-r.ready
-			if r.err != nil {
-				t.Error(r.err)
+			if r.Err != nil {
+				t.Error(r.Err)
 			}
 		}()
 	}
@@ -1306,7 +1306,7 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.err == nil {
+	if r.Err == nil {
 		t.Fatalf("expected bundle byte limit error, got nil")
 	}
 	// Publish a normal sized message now, which should fail
@@ -1317,8 +1317,8 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.err == nil || !strings.Contains(r.err.Error(), "pubsub: Publishing for ordering key") {
-		t.Fatalf("expected ordering keys publish error, got %v", r.err)
+	if r.Err == nil || !strings.Contains(r.Err.Error(), "pubsub: Publishing for ordering key") {
+		t.Fatalf("expected ordering keys publish error, got %v", r.Err)
 	}
 
 	// Lastly, call ResumePublish and make sure subsequent publishes succeed.
@@ -1329,8 +1329,8 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.err != nil {
-		t.Fatalf("got error while publishing message: %v", r.err)
+	if r.Err != nil {
+		t.Fatalf("got error while publishing message: %v", r.Err)
 	}
 }
 

--- a/pubsub/integration_test.go
+++ b/pubsub/integration_test.go
@@ -1133,8 +1133,8 @@ func TestIntegration_OrderedKeys_Basic(t *testing.T) {
 		})
 		go func() {
 			<-r.ready
-			if r.Err != nil {
-				t.Error(r.Err)
+			if r.err != nil {
+				t.Error(r.err)
 			}
 		}()
 	}
@@ -1306,7 +1306,7 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.Err == nil {
+	if r.err == nil {
 		t.Fatalf("expected bundle byte limit error, got nil")
 	}
 	// Publish a normal sized message now, which should fail
@@ -1317,8 +1317,8 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.Err == nil || !strings.Contains(r.Err.Error(), "pubsub: Publishing for ordering key") {
-		t.Fatalf("expected ordering keys publish error, got %v", r.Err)
+	if r.err == nil || !strings.Contains(r.err.Error(), "pubsub: Publishing for ordering key") {
+		t.Fatalf("expected ordering keys publish error, got %v", r.err)
 	}
 
 	// Lastly, call ResumePublish and make sure subsequent publishes succeed.
@@ -1329,8 +1329,8 @@ func TestIntegration_OrderedKeys_ResumePublish(t *testing.T) {
 		OrderingKey: orderingKey,
 	})
 	<-r.ready
-	if r.Err != nil {
-		t.Fatalf("got error while publishing message: %v", r.Err)
+	if r.err != nil {
+		t.Fatalf("got error while publishing message: %v", r.err)
 	}
 }
 

--- a/pubsub/pstest_test.go
+++ b/pubsub/pstest_test.go
@@ -123,14 +123,14 @@ func TestQueueError(t *testing.T) {
 	}
 	defer topic.Stop()
 
-	tesQueueError := errors.New("oops")
+	testQueueError := errors.New("oops")
 	pb.AddQueueError(tesQueueError)
 
 	r := topic.Publish(ctx, &pubsub.Message{
 		Data: []byte("hello world"),
 	})
 
-	if r.Err != tesQueueError {
+	if r.Err != testQueueError {
 		panic(r.Err)
 	}
 }

--- a/pubsub/pstest_test.go
+++ b/pubsub/pstest_test.go
@@ -24,9 +24,6 @@ import (
 	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
-
-	// pubSubWithQueueError "github.com/MarErm27/alicebob/pubsub"
-	pb "cloud.google.com/go/pubsub"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 )
@@ -96,6 +93,7 @@ func TestPSTest(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
 }
 
 func TestQueueError(t *testing.T) {
@@ -124,13 +122,13 @@ func TestQueueError(t *testing.T) {
 	defer topic.Stop()
 
 	testQueueError := errors.New("oops")
-	pb.AddQueueError(tesQueueError)
+	pubsub.AddQueueError(testQueueError)
 
 	r := topic.Publish(ctx, &pubsub.Message{
 		Data: []byte("hello world"),
 	})
-
-	if r.Err != testQueueError {
-		panic(r.Err)
+	_, err = r.Get(ctx)
+	if err != testQueueError {
+		t.Errorf("got %v, want "+testQueueError.Error(), err)
 	}
 }

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -404,7 +404,6 @@ func (t *Topic) Publish(ctx context.Context, msg *Message) *PublishResult {
 		err := QueueError
 		QueueError = nil
 		return &PublishResult{Err: err}
-
 	}
 
 	if !t.EnableMessageOrdering && msg.OrderingKey != "" {

--- a/pubsub/topic.go
+++ b/pubsub/topic.go
@@ -51,9 +51,10 @@ const (
 // ErrOversizedMessage indicates that a message's size exceeds MaxPublishRequestBytes.
 var ErrOversizedMessage = bundler.ErrOversizedItem
 
-// QueueError is a default value for err field in Publish function responce
+// QueueError indicates custom error for testing purposes
 var QueueError error
 
+// AddQueueError allows to test queue errors in Pub/Sub pstest
 func AddQueueError(e error) {
 	QueueError = e
 }


### PR DESCRIPTION
[Link to issue](https://github.com/googleapis/google-cloud-go/issues/1723)

The task is to provide the ability to test custom errors in [PublishResult](https://godoc.org/cloud.google.com/go/pubsub#PublishResult) structure after user call this function:
`res := topic.Publish(ctx, &pubsub.Message{Data: []byte("payload")})`

In topic.go file I added a function
```
// AddQueueError allows to test queue errors in Pub/Sub pstest
func AddQueueError(e error) {
	QueueError = e
}
```
, and a global variable
```
// QueueError indicates custom error for testing purposes
var QueueError error
```

at pstest_test.go I added a test that checks if a new functionality works
```
func TestQueueError(t *testing.T) {
	t.Parallel()
	ctx := context.Background()
	srv := pstest.NewServer()
	defer srv.Close()

	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
	if err != nil {
		panic(err)
	}
	defer conn.Close()

	opts := withGRPCHeadersAssertionAlt(t, option.WithGRPCConn(conn))
	client, err := pubsub.NewClient(ctx, "some-project", opts...)
	if err != nil {
		panic(err)
	}
	defer client.Close()

	topic, err := client.CreateTopic(ctx, "test-topic")
	if err != nil {
		panic(err)
	}
	defer topic.Stop()

	testQueueError := errors.New("oops")
	pb.AddQueueError(tesQueueError)

	r := topic.Publish(ctx, &pubsub.Message{
		Data: []byte("hello world"),
	})

	if r.Err != testQueueError {
		panic(r.Err)
	}
}
```
these rows
```
	testQueueError := errors.New("oops")
	pb.AddQueueError(tesQueueError)
```
add an error using the global variable QueueError in topic.go file and these rows
```
	if r.Err != testQueueError {
		panic(r.Err)
	}
```
check if an error in the responce equal to the one that we set. 

These rows
```
	if QueueError != nil {
		err := QueueError
		QueueError = nil
		return &PublishResult{Err: err}
	}
```
were added to Publish method to check the QueueError state. 